### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,10 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {


### PR DESCRIPTION
The code was fixed by replacing the direct concatenation of user input into the SQL query with a prepared statement. Specifically, the original line that constructed the SQL query using direct input (`$sql = "SELECT * FROM usuarios WHERE id = $id";`) was modified to use a prepared statement (`$stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");`). This change prevents SQL Injection by ensuring that user input is treated as a parameter rather than executable code. 

The `bind_param` method is then used to bind the user input (`$id`) to the prepared statement, specifying that the parameter is an integer (`"i"`). This not only sanitizes the input but also enhances performance by allowing the database to optimize the execution plan for the query. Finally, the statement is executed with `$stmt->execute()`, and the results are retrieved using `$stmt->get_result()`. 

Overall, this approach significantly mitigates the risk of SQL Injection attacks by ensuring that user input is properly handled and not directly embedded in the SQL query.

Created by: plexicus@plexicus.com