### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,10 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?"); 
+    $stmt->bind_param("i", $id); 
+    $stmt->execute(); 
+    $result = $stmt->get_result(); 
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {


### PR DESCRIPTION
The code was fixed by replacing the direct concatenation of user input into the SQL query with a prepared statement. Specifically, the original line that constructed the SQL query using direct input (`$sql = "SELECT * FROM usuarios WHERE id = $id";`) was changed to use a prepared statement (`$stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");`). This approach prevents SQL Injection by separating the SQL logic from the data, ensuring that user input is treated as a parameter rather than executable code. 

Additionally, the `bind_param` method was used to bind the user input (`$id`) to the prepared statement, specifying that it is an integer (`"i"`). This further enhances security by enforcing data type constraints. Finally, the statement is executed with `$stmt->execute()`, and the results are retrieved using `$stmt->get_result()`. 

Overall, this change effectively mitigates the risk of SQL Injection by ensuring that user input is properly sanitized and handled safely within the database query.

Created by: plexicus@plexicus.com