### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,10 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id);
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -38,4 +40,3 @@ if(isset($_GET['mensaje'])) {
 
 // Cerrar conexión
 $conn->close();
-?>


### PR DESCRIPTION
The code was fixed by replacing the direct concatenation of the user input (`$id`) into the SQL query with a prepared statement. Specifically, the original line `"SELECT * FROM usuarios WHERE id = $id"` was changed to use a prepared statement with placeholders. The new code uses `$stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?")`, which prepares the SQL statement without executing it immediately. Then, the `bind_param("i", $id)` method is called to bind the user input to the placeholder, specifying that the parameter is of type integer. Finally, the statement is executed with `$stmt->execute()`, and the results are fetched using `$stmt->get_result()`. 

This approach effectively mitigates the risk of SQL Injection by ensuring that user input is treated as a parameter rather than executable SQL code. Additionally, it is important to validate and sanitize user input before processing it, even when using prepared statements, to further enhance security. 

In a more general context, developers should always use prepared statements or parameterized queries when dealing with user input in SQL queries. This practice not only protects against SQL Injection but also promotes better coding standards and maintainability.

Created by: plexicus@plexicus.com