### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,15 +17,18 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
-
-    if ($result->num_rows > 0) {
-        while($row = $result->fetch_assoc()) {
-            echo "id: " . $row["id"]. " - Nombre: " . $row["nombre"]. "<br>";
+    $sql = "SELECT * FROM usuarios WHERE id = ?"; // Use prepared statement
+    $stmt = $conn->prepare($sql);
+    $stmt->bind_param("i", $id); // Bind the user input as an integer
+    $stmt->execute();
+    $result = $stmt->get_result();
+        if ($result->num_rows > 0) {
+            while($row = $result->fetch_assoc()) {
+                echo "id: " . $row["id"]. " - Nombre: " . $row["nombre"]. "<br>";
+            }
+        } else {
+            echo "0 resultados";
         }
-    } else {
-        echo "0 resultados";
     }
 }
 


### PR DESCRIPTION
The code was fixed by replacing the vulnerable direct concatenation of user input into the SQL query with a prepared statement. Specifically, the original line that constructed the SQL query using the user-provided 'id' parameter was changed from:

```php
$sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable to SQL Injection
```

to:

```php
$sql = "SELECT * FROM usuarios WHERE id = ?"; // Use prepared statement
$stmt = $conn->prepare($sql);
$stmt->bind_param("i", $id); // Bind the user input as an integer
```

This change effectively mitigates the risk of SQL Injection by ensuring that the user input is treated as a parameter rather than executable SQL code. The `bind_param` method specifies the type of the parameter ("i" for integer), which adds an additional layer of validation. 

Additional tips include:
1. Always validate and sanitize user inputs before using them in queries, even when using prepared statements.
2. Consider using an ORM (Object-Relational Mapping) library to abstract database interactions and further reduce the risk of SQL Injection.
3. Regularly review and test your code for vulnerabilities, especially when handling user input.

Created by: plexicus@plexicus.com