### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -16,9 +16,12 @@ if ($conn->connect_error) {
 // Vulnerabilidad de SQL Injection
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
+    // Input del usuario tomado directamente desde la URL
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Bind the parameter as an integer
+    $stmt->execute();
+    $result = $stmt->get_result();
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {
@@ -27,7 +30,6 @@ if(isset($_GET['id'])) {
     } else {
         echo "0 resultados";
     }
-}
 
 // Vulnerabilidad de Cross-Site Scripting (XSS)
 // El siguiente código es vulnerable a XSS ya que imprime directamente en el HTML el contenido de una variable que puede ser manipulada por el usuario sin ninguna sanitización.


### PR DESCRIPTION
The vulnerability was addressed by replacing the direct concatenation of the user-supplied 'id' parameter into the SQL query with a prepared statement. Instead of constructing the SQL query by inserting the 'id' directly into the string, we now use a parameterized query with a placeholder (?). The parameter is bound to an integer value using the bind_param() method. This modification ensures that the input is sanitized and handled appropriately by the database engine, effectively mitigating the risk of SQL Injection. It's a good practice to always use prepared statements for any SQL queries that rely on external input.

Created by: plexicus@plexicus.com